### PR TITLE
feat: add matrix helpers

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -85,7 +85,7 @@ fn main() {
         let function = function.clone();
         // Pull out basic info
         let name = function.name;
-        if !name.starts_with("anon") && !name.starts_with("_") && !name.starts_with("$CONSTANTS$"){
+        if !name.starts_with("anon") && !name.starts_with("_") && !name.starts_with("$CONSTANTS$") {
             let signature = function
                 .signature
                 .replace("Result<", "")
@@ -225,3 +225,8 @@ mod functions {
 
 #[cfg(feature = "metadata")]
 pub use functions::*;
+
+#[cfg(feature = "metadata")]
+pub mod matrix {
+    include!("src/matrix/mod.rs");
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -7,15 +7,15 @@ pub mod constant_definitions {
 
     // The ratio of a circle's circumference to its diameter.
     #[allow(non_upper_case_globals)]
-    pub const pi: FLOAT = 3.14159265358979323846264338327950288;
+    pub const pi: FLOAT = 3.141_592_653_589_793_238_462_643_383_279_502_88;
 
     //Speed of light in meters per second (m/s).
     #[allow(non_upper_case_globals)]
-    pub const c: FLOAT = 299792458.0;
+    pub const c: FLOAT = 299_792_458.0;
 
     // Euler's number.
     #[allow(non_upper_case_globals)]
-    pub const e: FLOAT = 2.71828182845904523536028747135266250;
+    pub const e: FLOAT = 2.718_281_828_459_045_235_360_287_471_352_662_50;
 
     // Acceleration due to gravity on Earth in meters per second per second (m/s^2).
     #[allow(non_upper_case_globals)]
@@ -23,14 +23,14 @@ pub mod constant_definitions {
 
     // The Planck constant in Joules per Hertz (J/Hz)
     #[allow(non_upper_case_globals)]
-    pub const h: FLOAT = 6.62607015e-34;
+    pub const h: FLOAT = 6.626_070_15e-34;
 
     // The golden ratio
     #[allow(non_upper_case_globals)]
-    pub const phi: FLOAT = 1.61803398874989484820;
+    pub const phi: FLOAT = 1.618_033_988_749_894_848_20;
 
     // Newtonian gravitational constant
-    pub const G: FLOAT = 6.6743015e-11;
+    pub const G: FLOAT = 6.674_301_5e-11;
 
     /// Physical constants useful for science.
     ///  ### `pi: FLOAT`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 
 mod patterns;
 pub use patterns::*;
+pub mod matrix;
+pub use matrix::{RhaiMatrix, RhaiVector};
 use rhai::{def_package, packages::Package, plugin::*, Engine, EvalAltResult};
 mod matrices_and_arrays;
 pub use matrices_and_arrays::matrix_functions;

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -1,0 +1,169 @@
+#[cfg(feature = "nalgebra")]
+use nalgebralib::{DMatrix, DVector};
+use rhai::{Array, Dynamic, EvalAltResult, Position, FLOAT};
+
+/// Wrapper around [`rhai::Array`] representing a matrix.
+///
+/// This type provides conversions between Rhai arrays and
+/// [`nalgebra::DMatrix`].
+///
+/// # Examples
+/// ```
+/// use rhai::{Array, Dynamic};
+/// use rhai_sci::matrix::RhaiMatrix;
+/// let raw: Array = vec![
+///     Dynamic::from_array(vec![Dynamic::from_float(1.0), Dynamic::from_float(2.0)]),
+///     Dynamic::from_array(vec![Dynamic::from_float(3.0), Dynamic::from_float(4.0)]),
+/// ];
+/// let matrix = RhaiMatrix::from_array(raw.clone());
+/// assert_eq!(matrix.to_array().len(), raw.len());
+/// ```
+#[derive(Clone, Debug)]
+pub struct RhaiMatrix(Array);
+
+impl RhaiMatrix {
+    /// Construct a [`RhaiMatrix`] from a [`rhai::Array`].
+    #[must_use]
+    pub fn from_array(arr: Array) -> Self {
+        Self(arr)
+    }
+
+    /// Convert the matrix back into a [`rhai::Array`].
+    #[must_use]
+    pub fn to_array(self) -> Array {
+        self.0
+    }
+
+    /// Convert the matrix into a [`nalgebra::DMatrix`].
+    ///
+    /// # Errors
+    /// Returns an error if any element is non-numeric or rows have differing lengths.
+    ///
+    /// # Panics
+    /// Panics if an integer value cannot be represented as `FLOAT`.
+    #[cfg(feature = "nalgebra")]
+    #[allow(clippy::cast_precision_loss)]
+    pub fn to_dmatrix(&self) -> Result<DMatrix<FLOAT>, Box<EvalAltResult>> {
+        if self.0.is_empty() {
+            return Ok(DMatrix::from_element(0, 0, 0.0));
+        }
+        let rows = self.0.len();
+        let first_row = self.0[0].clone().into_array().map_err(|_| {
+            EvalAltResult::ErrorArithmetic(
+                "Matrix must contain row arrays".to_string(),
+                Position::NONE,
+            )
+        })?;
+        let cols = first_row.len();
+        let mut dm = DMatrix::zeros(rows, cols);
+        for (i, row_dyn) in self.0.iter().enumerate() {
+            let row = row_dyn.clone().into_array().map_err(|_| {
+                EvalAltResult::ErrorArithmetic(
+                    "Matrix must contain row arrays".to_string(),
+                    Position::NONE,
+                )
+            })?;
+            if row.len() != cols {
+                return Err(EvalAltResult::ErrorArithmetic(
+                    "Matrix rows must have equal length".to_string(),
+                    Position::NONE,
+                )
+                .into());
+            }
+            for (j, val) in row.iter().enumerate() {
+                dm[(i, j)] = if val.is_float() {
+                    val.as_float().unwrap()
+                } else if val.is_int() {
+                    val.as_int().unwrap() as FLOAT
+                } else {
+                    return Err(EvalAltResult::ErrorArithmetic(
+                        "Matrix elements must be INT or FLOAT".to_string(),
+                        Position::NONE,
+                    )
+                    .into());
+                };
+            }
+        }
+        Ok(dm)
+    }
+
+    /// Create a [`RhaiMatrix`] from a [`nalgebra::DMatrix`].
+    #[cfg(feature = "nalgebra")]
+    #[must_use]
+    pub fn from_dmatrix(mat: &DMatrix<FLOAT>) -> Self {
+        let mut rows = Vec::with_capacity(mat.nrows());
+        for i in 0..mat.nrows() {
+            let mut row = Vec::with_capacity(mat.ncols());
+            for j in 0..mat.ncols() {
+                row.push(Dynamic::from_float(mat[(i, j)]));
+            }
+            rows.push(Dynamic::from_array(row));
+        }
+        Self(rows)
+    }
+}
+
+/// Wrapper around [`rhai::Array`] representing a vector.
+///
+/// # Examples
+/// ```
+/// use rhai::{Array, Dynamic};
+/// use rhai_sci::matrix::RhaiVector;
+/// let raw: Array = vec![Dynamic::from_float(1.0), Dynamic::from_float(2.0)];
+/// let vector = RhaiVector::from_array(raw.clone());
+/// assert_eq!(vector.to_array().len(), raw.len());
+/// ```
+#[derive(Clone, Debug)]
+pub struct RhaiVector(Array);
+
+impl RhaiVector {
+    /// Construct a [`RhaiVector`] from a [`rhai::Array`].
+    #[must_use]
+    pub fn from_array(arr: Array) -> Self {
+        Self(arr)
+    }
+
+    /// Convert the vector back into a [`rhai::Array`].
+    #[must_use]
+    pub fn to_array(self) -> Array {
+        self.0
+    }
+
+    /// Convert the vector into a [`nalgebra::DVector`].
+    ///
+    /// # Errors
+    /// Returns an error if any element is non-numeric.
+    ///
+    /// # Panics
+    /// Panics if an integer value cannot be represented as `FLOAT`.
+    #[cfg(feature = "nalgebra")]
+    #[allow(clippy::cast_precision_loss)]
+    pub fn to_dvector(&self) -> Result<DVector<FLOAT>, Box<EvalAltResult>> {
+        let mut dv = DVector::zeros(self.0.len());
+        for (i, val) in self.0.iter().enumerate() {
+            dv[i] = if val.is_float() {
+                val.as_float().unwrap()
+            } else if val.is_int() {
+                val.as_int().unwrap() as FLOAT
+            } else {
+                return Err(EvalAltResult::ErrorArithmetic(
+                    "Vector elements must be INT or FLOAT".to_string(),
+                    Position::NONE,
+                )
+                .into());
+            };
+        }
+        Ok(dv)
+    }
+
+    /// Create a [`RhaiVector`] from a [`nalgebra::DVector`].
+    #[cfg(feature = "nalgebra")]
+    #[must_use]
+    pub fn from_dvector(vec: &DVector<FLOAT>) -> Self {
+        let mut data = Vec::with_capacity(vec.len());
+        for i in 0..vec.len() {
+            data.push(Dynamic::from_float(vec[i]));
+        }
+        Self(data)
+    }
+}

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -1,3 +1,4 @@
+use crate::matrix::{RhaiMatrix, RhaiVector};
 use rhai::{Array, Dynamic, EvalAltResult, Position, FLOAT, INT};
 
 /// Matrix compatibility conditions
@@ -227,37 +228,31 @@ where
 }
 
 pub fn array_to_vec_int(arr: &mut Array) -> Vec<INT> {
-    arr.iter()
-        .map(|el| el.as_int().unwrap())
-        .collect::<Vec<INT>>()
+    RhaiVector::from_array(arr.clone())
+        .to_dvector()
+        .expect("Array elements must be numeric")
+        .iter()
+        .map(|v| *v as INT)
+        .collect()
 }
 
 pub fn array_to_vec_float(arr: &mut Array) -> Vec<FLOAT> {
-    arr.into_iter()
-        .map(|el| el.as_float().unwrap())
-        .collect::<Vec<FLOAT>>()
+    RhaiVector::from_array(arr.clone())
+        .to_dvector()
+        .expect("Array elements must be numeric")
+        .iter()
+        .copied()
+        .collect()
 }
 
 #[cfg(feature = "nalgebra")]
 pub fn omatrix_to_vec_dynamic(
     mat: nalgebralib::OMatrix<FLOAT, nalgebralib::Dyn, nalgebralib::Dyn>,
 ) -> Vec<Dynamic> {
-    let mut out = vec![];
-    for idx in 0..mat.shape().0 {
-        let mut new_row = vec![];
-        for jdx in 0..mat.shape().1 {
-            new_row.push(Dynamic::from_float(mat[(idx, jdx)]));
-        }
-        out.push(Dynamic::from_array(new_row));
-    }
-    out
+    RhaiMatrix::from_dmatrix(&mat).to_array()
 }
 
 #[cfg(feature = "nalgebra")]
 pub fn ovector_to_vec_dynamic(mat: nalgebralib::OVector<FLOAT, nalgebralib::Dyn>) -> Vec<Dynamic> {
-    let mut out = vec![];
-    for idx in 0..mat.shape().0 {
-        out.push(Dynamic::from_float(mat[idx]));
-    }
-    out
+    RhaiVector::from_dvector(&mat).to_array()
 }


### PR DESCRIPTION
## Summary
- add RhaiMatrix and RhaiVector wrappers for Rhai arrays
- centralize matrix and vector conversions via helper module
- use conversion helpers across matrix utilities

## Testing
- `cargo fmt --all`
- `cargo clippy --all-features -- -D warnings -D clippy::pedantic` (fails: unresolved imports and pedantic lints)
- `cargo test` (fails: doctest linking errors)


------
https://chatgpt.com/codex/tasks/task_e_68bcc1986ff4832597ad71d2efda3b3d