### PR TITLE
Add vector orientation helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ engine.register_global_module(SciPackage::new().as_shared_module());
 let value = engine.eval::<INT>("argmin([43, 42, -500])").unwrap();
 ```
 
+## Matrix helpers
+
+`rhai-sci` provides constructors for row and column vectors and utilities to reorient
+`1×N` and `N×1` matrices:
+
+```rust
+use rhai::{Array, Dynamic};
+use rhai_sci::matrix::RhaiMatrix;
+
+let data: Array = vec![Dynamic::from_int(1), Dynamic::from_int(2)];
+let row = RhaiMatrix::row_vector(data.clone());
+let column = row.as_column().unwrap();
+```
+
 # Features
 
 | Feature    | Default  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |

--- a/src/matrices_and_arrays.rs
+++ b/src/matrices_and_arrays.rs
@@ -337,7 +337,7 @@ pub mod matrix_functions {
             .count() as INT
     }
 
-    #[cfg(all(feature = "io"))]
+    #[cfg(feature = "io")]
     pub mod read_write {
         use polars::prelude::{CsvReadOptions, DataType, SerReader};
         use rhai::{Array, Dynamic, EvalAltResult, ImmutableString, FLOAT};

--- a/src/trig.rs
+++ b/src/trig.rs
@@ -2,8 +2,7 @@ use rhai::plugin::*;
 
 #[export_module]
 pub mod trig_functions {
-    use crate::if_int_convert_to_float_and_do;
-    use rhai::{Array, Dynamic, EvalAltResult, Position, FLOAT, INT};
+    use rhai::{Array, Dynamic, FLOAT};
 
     /// Converts the argument from degrees to radians
     /// ```typescript

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -2,6 +2,7 @@ use rhai::plugin::*;
 
 #[export_module]
 pub mod validation_functions {
+    use crate::matrix::RhaiMatrix;
     use rhai::{Array, Dynamic};
 
     /// Tests whether the input in a simple list array
@@ -113,9 +114,10 @@ pub mod validation_functions {
     /// ```
     #[rhai_fn(name = "is_row_vector", pure)]
     pub fn is_row_vector(arr: &mut Array) -> bool {
-        let s = crate::matrix_functions::matrix_size_by_reference(arr);
-        if s.len() == 2 && s[0].as_int().unwrap() == 1 {
-            true
+        let matrix = RhaiMatrix::from_array(arr.clone());
+        if matrix.as_row().is_some() {
+            let s = crate::matrix_functions::matrix_size_by_reference(arr);
+            s.len() == 2 && s[0].as_int().unwrap() == 1_i64
         } else {
             false
         }
@@ -132,9 +134,10 @@ pub mod validation_functions {
     /// ```
     #[rhai_fn(name = "is_column_vector", pure)]
     pub fn is_column_vector(arr: &mut Array) -> bool {
-        let s = crate::matrix_functions::matrix_size_by_reference(arr);
-        if s.len() == 2 && s[1].as_int().unwrap() == 1 {
-            true
+        let matrix = RhaiMatrix::from_array(arr.clone());
+        if matrix.as_column().is_some() {
+            let s = crate::matrix_functions::matrix_size_by_reference(arr);
+            s.len() == 2 && s[1].as_int().unwrap() == 1_i64
         } else {
             false
         }

--- a/tests/orientation.rs
+++ b/tests/orientation.rs
@@ -1,0 +1,34 @@
+use rhai::{Array, Dynamic};
+use rhai_sci::matrix::RhaiMatrix;
+use rhai_sci::validation_functions::{is_column_vector, is_row_vector};
+
+#[test]
+fn row_column_constructors_and_orientation() {
+    let data: Array = vec![
+        Dynamic::from_int(1),
+        Dynamic::from_int(2),
+        Dynamic::from_int(3),
+    ];
+    let row = RhaiMatrix::row_vector(data.clone());
+    let column = RhaiMatrix::column_vector(data.clone());
+    let mut row_to_col = row.as_column().unwrap().to_array();
+    assert!(is_column_vector(&mut row_to_col));
+    let mut col_to_row = column.as_row().unwrap().to_array();
+    assert!(is_row_vector(&mut col_to_row));
+}
+
+#[test]
+fn validate_orientation_helpers() {
+    let mut row: Array = vec![Dynamic::from_array(vec![
+        Dynamic::from_int(1),
+        Dynamic::from_int(2),
+    ])];
+    let column: Array = vec![
+        Dynamic::from_array(vec![Dynamic::from_int(1)]),
+        Dynamic::from_array(vec![Dynamic::from_int(2)]),
+    ];
+    assert!(is_row_vector(&mut row.clone()));
+    assert!(!is_row_vector(&mut column.clone()));
+    assert!(is_column_vector(&mut column.clone()));
+    assert!(!is_column_vector(&mut row));
+}


### PR DESCRIPTION
## Summary
- add `row_vector`/`column_vector` constructors to `RhaiMatrix`
- provide `as_row` and `as_column` helpers
- delegate vector checks in validation to orientation helpers and add tests

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings -D clippy::pedantic` *(fails: missing docs, unused imports, etc.)*
- `cargo test` *(doc tests fail: linking with `cc`)*
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68bccd868c6c83258b0b4e6aaa06fd09