### PR TITLE
docs: clarify matrix orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,19 +43,26 @@ engine.register_global_module(SciPackage::new().as_shared_module());
 let value = engine.eval::<INT>("argmin([43, 42, -500])").unwrap();
 ```
 
-## Matrix helpers
+## Matrix & Vector Conventions
 
-`rhai-sci` provides constructors for row and column vectors and utilities to reorient
-`1×N` and `N×1` matrices:
+Matrices use the conventional `n×m` shape where `n` is the number of rows and `m`
+is the number of columns. Row vectors have shape `1×n` and column vectors use
+`n×1`.
+
+`rhai-sci` provides helpers for constructing and reorienting these shapes:
 
 ```rust
 use rhai::{Array, Dynamic};
 use rhai_sci::matrix::RhaiMatrix;
 
 let data: Array = vec![Dynamic::from_int(1), Dynamic::from_int(2)];
-let row = RhaiMatrix::row_vector(data.clone());
-let column = row.as_column().unwrap();
+let row = RhaiMatrix::row_vector(data.clone());      // 1×2
+let column = row.as_column().unwrap();               // 2×1
 ```
+
+The `row_vector` and `column_vector` constructors create oriented vectors,
+while `as_row` and `as_column` convert `1×n` and `n×1` matrices between the two
+orientations.
 
 # Features
 

--- a/src/matrices_and_arrays.rs
+++ b/src/matrices_and_arrays.rs
@@ -899,10 +899,10 @@ pub mod matrix_functions {
 
     /// Concatenate two arrays horizontally.
     /// ```typescript
-    /// let arr1 = eye(3);
-    /// let arr2 = eye(3);
-    /// let combined = horzcat(arr1, arr2);
-    /// assert_eq(size(combined), [3, 6]);
+    /// let left = [[1, 2]];
+    /// let right = [[3, 4]];
+    /// let row = horzcat(left, right);
+    /// assert_eq(row, [[1.0, 2.0, 3.0, 4.0]]);
     /// ```
     #[cfg(feature = "nalgebra")]
     #[rhai_fn(name = "horzcat", return_raw)]
@@ -927,10 +927,10 @@ pub mod matrix_functions {
 
     /// Concatenates two array vertically.
     /// ```typescript
-    /// let arr1 = eye(3);
-    /// let arr2 = eye(3);
-    /// let combined = vertcat(arr1, arr2);
-    /// assert_eq(size(combined), [6, 3]);
+    /// let top = [[1], [2]];
+    /// let bottom = [[3], [4]];
+    /// let column = vertcat(top, bottom);
+    /// assert_eq(column, [[1.0], [2.0], [3.0], [4.0]]);
     /// ```
     #[cfg(feature = "nalgebra")]
     #[rhai_fn(name = "vertcat", return_raw)]

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -5,7 +5,7 @@ use rhai::{Array, Dynamic, EvalAltResult, Position, FLOAT};
 /// Wrapper around [`rhai::Array`] representing a matrix.
 ///
 /// This type provides conversions between Rhai arrays and
-/// [`nalgebra::DMatrix`].
+/// `nalgebra::DMatrix`.
 ///
 /// # Examples
 /// ```
@@ -130,7 +130,7 @@ impl RhaiMatrix {
         self.0
     }
 
-    /// Convert the matrix into a [`nalgebra::DMatrix`].
+    /// Convert the matrix into a `nalgebra::DMatrix`.
     ///
     /// # Errors
     /// Returns an error if any element is non-numeric or rows have differing lengths.
@@ -183,7 +183,7 @@ impl RhaiMatrix {
         Ok(dm)
     }
 
-    /// Create a [`RhaiMatrix`] from a [`nalgebra::DMatrix`].
+    /// Create a [`RhaiMatrix`] from a `nalgebra::DMatrix`.
     #[cfg(feature = "nalgebra")]
     #[must_use]
     pub fn from_dmatrix(mat: &DMatrix<FLOAT>) -> Self {
@@ -211,6 +211,16 @@ impl RhaiMatrix {
 
     /// Horizontally concatenate two matrices.
     ///
+    /// # Examples
+    /// ```
+    /// use rhai::{Array, Dynamic};
+    /// use rhai_sci::{matrix::RhaiMatrix, validation_functions::is_row_vector};
+    /// let left = RhaiMatrix::row_vector(vec![Dynamic::from_int(1), Dynamic::from_int(2)]);
+    /// let right = RhaiMatrix::row_vector(vec![Dynamic::from_int(3), Dynamic::from_int(4)]);
+    /// let combined = left.concat_h(&right).unwrap();
+    /// let mut arr = combined.to_array();
+    /// assert!(is_row_vector(&mut arr));
+    /// ```
     /// # Errors
     /// Returns an error if the matrices have differing row counts or contain
     /// non-numeric values.
@@ -239,6 +249,16 @@ impl RhaiMatrix {
 
     /// Vertically concatenate two matrices.
     ///
+    /// # Examples
+    /// ```
+    /// use rhai::{Array, Dynamic};
+    /// use rhai_sci::{matrix::RhaiMatrix, validation_functions::is_column_vector};
+    /// let top = RhaiMatrix::column_vector(vec![Dynamic::from_int(1), Dynamic::from_int(2)]);
+    /// let bottom = RhaiMatrix::column_vector(vec![Dynamic::from_int(3), Dynamic::from_int(4)]);
+    /// let combined = top.concat_v(&bottom).unwrap();
+    /// let mut arr = combined.to_array();
+    /// assert!(is_column_vector(&mut arr));
+    /// ```
     /// # Errors
     /// Returns an error if the matrices have differing column counts or contain
     /// non-numeric values.
@@ -292,7 +312,7 @@ impl RhaiVector {
         self.0
     }
 
-    /// Convert the vector into a [`nalgebra::DVector`].
+    /// Convert the vector into a `nalgebra::DVector`.
     ///
     /// # Errors
     /// Returns an error if any element is non-numeric.
@@ -319,7 +339,7 @@ impl RhaiVector {
         Ok(dv)
     }
 
-    /// Create a [`RhaiVector`] from a [`nalgebra::DVector`].
+    /// Create a [`RhaiVector`] from a `nalgebra::DVector`.
     #[cfg(feature = "nalgebra")]
     #[must_use]
     pub fn from_dvector(vec: &DVector<FLOAT>) -> Self {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -103,14 +103,14 @@ pub mod validation_functions {
         }
     }
 
-    /// Tests whether the input is a row vector
+    /// Tests whether the input is a row vector.
     /// ```typescript
-    /// let x = ones([1, 5]);
-    /// assert_eq(is_row_vector(x), true)
+    /// let row = [[1, 2, 3]];
+    /// assert_eq(is_row_vector(row), true);
     /// ```
     /// ```typescript
-    /// let x = ones([5, 5]);
-    /// assert_eq(is_row_vector(x), false)
+    /// let column = [[1], [2], [3]];
+    /// assert_eq(is_row_vector(column), false);
     /// ```
     #[rhai_fn(name = "is_row_vector", pure)]
     pub fn is_row_vector(arr: &mut Array) -> bool {
@@ -123,14 +123,14 @@ pub mod validation_functions {
         }
     }
 
-    /// Tests whether the input is a column vector
+    /// Tests whether the input is a column vector.
     /// ```typescript
-    /// let x = ones([5, 1]);
-    /// assert_eq(is_column_vector(x), true)
+    /// let column = [[1], [2], [3]];
+    /// assert_eq(is_column_vector(column), true);
     /// ```
     /// ```typescript
-    /// let x = ones([5, 5]);
-    /// assert_eq(is_column_vector(x), false)
+    /// let row = [[1, 2, 3]];
+    /// assert_eq(is_column_vector(row), false);
     /// ```
     #[rhai_fn(name = "is_column_vector", pure)]
     pub fn is_column_vector(arr: &mut Array) -> bool {


### PR DESCRIPTION
## Summary
- document matrix and vector orientation conventions in README
- show row/column vector usage in matrix helpers and validation docs
- add examples for horizontal/vertical concatenation

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::pedantic` *(fails: countless pre-existing warnings)*
- `cargo test --no-default-features --features nalgebra`
- `cargo test --doc --no-default-features --features nalgebra`
- `cargo doc --no-deps --no-default-features --features nalgebra`


------
https://chatgpt.com/codex/tasks/task_e_68be1ea394308325a363df79d9e59c16