### PR TITLE
Add matrix inversion example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ engine.register_global_module(SciPackage::new().as_shared_module());
 let value = engine.eval::<INT>("argmin([43, 42, -500])").unwrap();
 ```
 
+## Examples
+
+The `examples/` directory contains runnable snippets that showcase `rhai-sci` in action:
+
+- `download_and_regress.rs` – download CSV data and perform a linear regression.
+- `matrix_inversion.rs` – compute the inverse of a small matrix using `inv`.
+
+Run any example with `cargo run --example <name>`.
+
 ## Matrix & Vector Conventions
 
 Matrices use the conventional `n×m` shape where `n` is the number of rows and `m`

--- a/examples/matrix_inversion.rhai
+++ b/examples/matrix_inversion.rhai
@@ -1,0 +1,4 @@
+let m = [[1, 2], [3, 4]];
+let inv_m = inv(m);
+print(inv_m);
+inv_m

--- a/examples/matrix_inversion.rs
+++ b/examples/matrix_inversion.rs
@@ -1,0 +1,21 @@
+//! Demonstrates computing the inverse of a matrix using rhai-sci.
+
+fn main() {
+    #[cfg(feature = "nalgebra")]
+    {
+        use rhai::{packages::Package, Engine};
+        use rhai_sci::SciPackage;
+
+        // Create a new Rhai engine
+        let mut engine = Engine::new();
+
+        // Add the rhai-sci package to the engine
+        engine.register_global_module(SciPackage::new().as_shared_module());
+
+        // Run the script that inverts a matrix
+        let result = engine
+            .run_file("examples/matrix_inversion.rhai".into())
+            .expect("script should run");
+        println!("{:?}", result);
+    }
+}

--- a/tests/matrix_inverse_example.rs
+++ b/tests/matrix_inverse_example.rs
@@ -1,0 +1,24 @@
+#![cfg(feature = "nalgebra")]
+use rhai::{packages::Package, Array, Engine};
+use rhai_sci::SciPackage;
+
+#[test]
+fn matrix_inverse_example_produces_expected_result() {
+    let mut engine = Engine::new();
+    engine.register_global_module(SciPackage::new().as_shared_module());
+
+    let result: Array = engine
+        .eval("inv([[1, 2], [3, 4]])")
+        .expect("script evaluation should succeed");
+
+    let first_row: Array = result[0].clone().cast::<Array>();
+    let second_row: Array = result[1].clone().cast::<Array>();
+
+    let r0: Vec<f64> = first_row.into_iter().map(|v| v.cast::<f64>()).collect();
+    let r1: Vec<f64> = second_row.into_iter().map(|v| v.cast::<f64>()).collect();
+
+    assert!((r0[0] + 2.0).abs() < f64::EPSILON);
+    assert!((r0[1] - 1.0).abs() < f64::EPSILON);
+    assert!((r1[0] - 1.5).abs() < f64::EPSILON);
+    assert!((r1[1] + 0.5).abs() < f64::EPSILON);
+}


### PR DESCRIPTION
## Summary
- add matrix inversion example that runs a Rhai script
- test inverse calculation with `inv` helper
- document examples in README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` (fails: this function could have a `#[must_use]` attribute)
- `cargo test --all-features` (fails: linking with `cc` failed: exit status: 1)


------
https://chatgpt.com/codex/tasks/task_e_68be2230c4c08325b6f884e2a7e8a20b