### PR TITLE
Add projectile motion example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ engine.register_global_module(SciPackage::new().as_shared_module());
 let value = engine.eval::<INT>("argmin([43, 42, -500])").unwrap();
 ```
 
+See the `examples` directory for more:
+
+- `matrix_inversion.rhai` demonstrates matrix inversion.
+- `download_and_regress.rhai` fetches data and performs linear regression.
+- `projectile_motion.rhai` uses trigonometry and array utilities to simulate a projectile trajectory.
+
 ### Features
 
 - **metadata** *(disabled)*: export function metadata; required for running doc-tests on Rhai examples.

--- a/examples/projectile_motion.rhai
+++ b/examples/projectile_motion.rhai
@@ -1,0 +1,33 @@
+// Simulate simple projectile motion using rhai-sci functions
+let g = 9.81;           // gravitational acceleration (m/s^2)
+let v0 = 25.0;          // launch speed (m/s)
+let angle = 45.0;       // launch angle (degrees)
+
+// Generate a time vector from 0 to total flight time
+let t_flight = 2.0 * v0 * sind(angle) / g;
+let times = linspace(0.0, t_flight, 50);
+
+let vx = v0 * cosd(angle);
+let vy0 = v0 * sind(angle);
+
+let x = [];
+let y = [];
+
+for t in times {
+    x.push(vx * t);
+    y.push(vy0 * t - 0.5 * g * t * t);
+}
+
+let max_y = max(y);
+let idx = argmax(y);
+let peak_time = times[idx];
+let range = max(x);
+
+let result = #{
+    "max_height": max_y,
+    "time_of_flight": t_flight,
+    "peak_time": peak_time,
+    "range": range
+};
+print(result);
+result

--- a/examples/projectile_motion.rs
+++ b/examples/projectile_motion.rs
@@ -1,0 +1,14 @@
+//! Simulates projectile motion using rhai-sci.
+
+fn main() {
+    use rhai::{packages::Package, Engine};
+    use rhai_sci::SciPackage;
+
+    let mut engine = Engine::new();
+    engine.register_global_module(SciPackage::new().as_shared_module());
+
+    let result: rhai::Map = engine
+        .eval_file("examples/projectile_motion.rhai".into())
+        .expect("script should run");
+    println!("{result:?}");
+}

--- a/tests/projectile_motion_example.rs
+++ b/tests/projectile_motion_example.rs
@@ -1,0 +1,28 @@
+use rhai::{packages::Package, Engine, Map};
+use rhai_sci::SciPackage;
+
+#[test]
+fn projectile_motion_example_produces_expected_result() {
+    // Arrange: set up engine with rhai-sci package
+    let mut engine = Engine::new();
+    engine.register_global_module(SciPackage::new().as_shared_module());
+
+    // Act: evaluate projectile motion script
+    let result: Map = engine
+        .eval_file("examples/projectile_motion.rhai".into())
+        .expect("script evaluation should succeed");
+
+    // Assert: compare against analytical solution
+    let max_height = result["max_height"].clone().cast::<f64>();
+    let time_of_flight = result["time_of_flight"].clone().cast::<f64>();
+    let range = result["range"].clone().cast::<f64>();
+
+    let expected_max_height =
+        (25.0_f64.powi(2) * (45_f64.to_radians().sin().powi(2))) / (2.0 * 9.81);
+    let expected_time_of_flight = 2.0 * 25.0 * 45_f64.to_radians().sin() / 9.81;
+    let expected_range = (25.0_f64.powi(2) * (2.0 * 45_f64.to_radians()).sin()) / 9.81;
+
+    assert!((max_height - expected_max_height).abs() < 1e-2);
+    assert!((time_of_flight - expected_time_of_flight).abs() < 1e-6);
+    assert!((range - expected_range).abs() < 1e-6);
+}


### PR DESCRIPTION
## Summary
- document existing examples and add projectile motion walkthrough
- add projectile motion example and corresponding test

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic` *(fails: needless_bool etc in existing code)*
- `cargo test --no-default-features --features rand,nalgebra`
- `cargo doc --no-deps --all-features`


------
https://chatgpt.com/codex/tasks/task_e_68bed5a4dfd88325914b516384ee4288