### PR TITLE
Handle vector inputs in diag

### DIFF
--- a/src/matrices_and_arrays.rs
+++ b/src/matrices_and_arrays.rs
@@ -4,6 +4,7 @@ use rhai::plugin::*;
 pub mod matrix_functions {
     #[cfg(feature = "nalgebra")]
     use crate::matrix::{RhaiMatrix, RhaiVector};
+    use crate::validation_functions::{is_column_vector, is_row_vector};
     use crate::{
         array_to_vec_float, if_int_convert_to_float_and_do, if_int_do_else_if_array_do, if_list_do,
         if_matrix_convert_to_vec_array_and_do,
@@ -984,44 +985,60 @@ pub mod matrix_functions {
     /// ```
     #[rhai_fn(name = "diag", return_raw)]
     pub fn diag(matrix: Array) -> Result<Array, Box<EvalAltResult>> {
-        if ndims_by_reference(&mut matrix.clone()) == 2 {
-            // Turn into Vec<Array>
+        let dims = ndims_by_reference(&mut matrix.clone());
+        if dims == 2 {
+            let mut candidate_for_row = matrix.clone();
+            let mut candidate_for_col = matrix.clone();
+            if is_row_vector(&mut candidate_for_row) || is_column_vector(&mut candidate_for_col) {
+                let mut flattened_vector = matrix.clone();
+                let vector = flatten(&mut flattened_vector);
+                return Ok(diagonal_matrix_from_vector(vector));
+            }
+
             let matrix_as_vec = matrix
                 .into_iter()
                 .map(|x| x.into_array().unwrap())
                 .collect::<Vec<Array>>();
 
+            if matrix_as_vec.is_empty() {
+                return Ok(vec![]);
+            }
+
+            let cols = matrix_as_vec[0].len();
+            let diag_len = matrix_as_vec.len().min(cols);
             let mut out = vec![];
-            for i in 0..matrix_as_vec.len() {
+            for i in 0..diag_len {
                 out.push(matrix_as_vec[i][i].clone());
             }
 
             Ok(out)
-        } else if ndims_by_reference(&mut matrix.clone()) == 1 {
-            let mut out = vec![];
-            for idx in 0..matrix.len() {
-                let mut new_row = vec![];
-                for jdx in 0..matrix.len() {
-                    if idx == jdx {
-                        new_row.push(matrix[idx].clone());
-                    } else {
-                        if matrix[idx].is_int() {
-                            new_row.push(Dynamic::ZERO);
-                        } else {
-                            new_row.push(Dynamic::FLOAT_ZERO);
-                        }
-                    }
-                }
-                out.push(Dynamic::from_array(new_row));
-            }
-            Ok(out)
+        } else if dims == 1 {
+            Ok(diagonal_matrix_from_vector(matrix))
         } else {
-            return Err(EvalAltResult::ErrorArithmetic(
+            Err(EvalAltResult::ErrorArithmetic(
                 "Argument must be a 2-D matrix (to extract the diagonal) or a 1-D array (to create a matrix with that diagonal".to_string(),
                 Position::NONE,
             )
-                .into());
+            .into())
         }
+    }
+
+    fn diagonal_matrix_from_vector(vector: Array) -> Array {
+        let mut out = vec![];
+        for idx in 0..vector.len() {
+            let mut new_row = vec![];
+            for jdx in 0..vector.len() {
+                if idx == jdx {
+                    new_row.push(vector[idx].clone());
+                } else if vector[idx].is_int() {
+                    new_row.push(Dynamic::ZERO);
+                } else {
+                    new_row.push(Dynamic::FLOAT_ZERO);
+                }
+            }
+            out.push(Dynamic::from_array(new_row));
+        }
+        out
     }
 
     /// Repeats copies of a matrix

--- a/tests/matrix_ops.rs
+++ b/tests/matrix_ops.rs
@@ -1,7 +1,7 @@
 use rhai::{Array, Dynamic, FLOAT, INT};
 use rhai_sci::matrix::RhaiMatrix;
 use rhai_sci::matrix_functions::{
-    horzcat, matrix_size_by_reference, meshgrid, repmat, transpose, vertcat,
+    diag, horzcat, matrix_size_by_reference, meshgrid, repmat, transpose, vertcat,
 };
 use rhai_sci::validation_functions::{is_column_vector, is_row_vector};
 
@@ -103,4 +103,65 @@ fn meshgrid_matches_matlab_shape_for_mismatched_lengths() {
         })
         .collect();
     assert_eq!(y_rows, vec![vec![4, 4, 4], vec![5, 5, 5]]);
+}
+
+fn matrix_to_ints(matrix: Array) -> Vec<Vec<INT>> {
+    matrix
+        .into_iter()
+        .map(|row| {
+            row.into_array()
+                .unwrap()
+                .into_iter()
+                .map(|d| d.as_int().unwrap())
+                .collect()
+        })
+        .collect()
+}
+
+#[test]
+fn diag_treats_row_and_column_vectors_equally() {
+    let column: Array = vec![
+        Dynamic::from_array(vec![Dynamic::from_int(1)]),
+        Dynamic::from_array(vec![Dynamic::from_int(2)]),
+        Dynamic::from_array(vec![Dynamic::from_int(3)]),
+    ];
+    let row: Array = vec![Dynamic::from_array(vec![
+        Dynamic::from_int(1),
+        Dynamic::from_int(2),
+        Dynamic::from_int(3),
+    ])];
+
+    let column_diag = diag(column).unwrap();
+    let row_diag = diag(row).unwrap();
+
+    let column_values = matrix_to_ints(column_diag.clone());
+    let row_values = matrix_to_ints(row_diag.clone());
+    assert_eq!(column_values, row_values);
+
+    let expected = vec![vec![1, 0, 0], vec![0, 2, 0], vec![0, 0, 3]];
+    assert_eq!(row_values, expected);
+}
+
+#[test]
+fn diag_extracts_from_rectangular_matrices() {
+    let matrix: Array = vec![
+        Dynamic::from_array(vec![
+            Dynamic::from_int(1),
+            Dynamic::from_int(2),
+            Dynamic::from_int(3),
+        ]),
+        Dynamic::from_array(vec![
+            Dynamic::from_int(4),
+            Dynamic::from_int(5),
+            Dynamic::from_int(6),
+        ]),
+    ];
+
+    let diag_values = diag(matrix).unwrap();
+    let ints: Vec<INT> = diag_values
+        .into_iter()
+        .map(|d| d.as_int().unwrap())
+        .collect();
+    let expected = vec![1, 5];
+    assert_eq!(ints, expected);
 }


### PR DESCRIPTION
## Summary
- detect row and column vectors in `diag`, flatten them, and reuse a helper to construct diagonal matrices
- clamp diagonal extraction of rectangular matrices to the smaller dimension so non-square inputs work without panics
- add regression tests that cover vector inputs and rectangular matrices for `diag`

## Testing
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic` *(fails: existing warnings/errors in validation and trig modules unrelated to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69191efd784883258b3b07454e0dc1a8)