### PR TITLE
[codex] Add matrix convention helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See the `examples` directory for more:
 - `matrix_inversion.rhai` demonstrates matrix inversion.
 - `download_and_regress.rhai` fetches data and performs linear regression.
 - `projectile_motion.rhai` uses trigonometry and array utilities to simulate a projectile trajectory.
+- `neural_network_backprop.rhai` trains a tiny neural network on XOR with explicit backpropagation.
 
 ## Matrix and Vector Conventions
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,41 @@ See the `examples` directory for more:
 - `download_and_regress.rhai` fetches data and performs linear regression.
 - `projectile_motion.rhai` uses trigonometry and array utilities to simulate a projectile trajectory.
 
+## Matrix and Vector Conventions
+
+Rhai arrays remain the storage model. Use constructors when shape matters:
+
+```typescript
+let values = [1, 2, 3];        // plain Rhai list
+let x = vec([1, 2, 3]);        // column vector: [[1], [2], [3]]
+let c = col([1, 2, 3]);        // column vector: [[1], [2], [3]]
+let r = row([1, 2, 3]);        // row vector: [[1, 2, 3]]
+let A = mat([[1, 2], [3, 4]]); // validated matrix
+```
+
+For compact matrix literals, use strings with whitespace, commas, and semicolons:
+
+```typescript
+let A = mat("1 2; 3 4");
+let B = M("1, 2; 3, 4");
+let r = R("1 2 3");
+let c = C("1; 2; 3");
+```
+
+The short aliases keep linear algebra scripts readable:
+
+```typescript
+let A = mat("1 2; 3 4");
+let x = col([5, 6]);
+let y = row([7, 8]);
+
+let z = dot(A, x);
+let z2 = A.dot(x);
+let At = T(A);
+let C = hcat(A, x);
+let D = vcat(A, y);
+```
+
 ### Features
 
 - **metadata** *(disabled)*: export function metadata; required for running doc-tests on Rhai examples.
@@ -75,4 +110,3 @@ Licensed under either of
 - [Apache License, Version 2.0](LICENSE-APACHE.txt)
 
 at your option.
-

--- a/examples/neural_network_backprop.rhai
+++ b/examples/neural_network_backprop.rhai
@@ -1,0 +1,199 @@
+// Train a tiny 2-2-1 neural network on XOR with explicit backpropagation.
+
+fn sigmoid(x) {
+    1.0 / (1.0 + exp(0.0 - x))
+}
+
+fn sigmoid_matrix(A) {
+    let out = [];
+
+    for row in A {
+        let out_row = [];
+        for value in row {
+            out_row.push(sigmoid(value));
+        }
+        out.push(out_row);
+    }
+
+    out
+}
+
+fn sigmoid_prime_from_activation(A) {
+    let out = [];
+
+    for row in A {
+        let out_row = [];
+        for value in row {
+            out_row.push(value * (1.0 - value));
+        }
+        out.push(out_row);
+    }
+
+    out
+}
+
+fn sub_matrix(A, B) {
+    let out = [];
+
+    for i in 0..A.len() {
+        let a_row = A[i];
+        let b_row = B[i];
+        let row = [];
+        for j in 0..a_row.len() {
+            row.push(a_row[j] - b_row[j]);
+        }
+        out.push(row);
+    }
+
+    out
+}
+
+fn scale_matrix(A, scale) {
+    let out = [];
+
+    for row in A {
+        let out_row = [];
+        for value in row {
+            out_row.push(value * scale);
+        }
+        out.push(out_row);
+    }
+
+    out
+}
+
+fn hadamard(A, B) {
+    let out = [];
+
+    for i in 0..A.len() {
+        let a_row = A[i];
+        let b_row = B[i];
+        let row = [];
+        for j in 0..a_row.len() {
+            row.push(a_row[j] * b_row[j]);
+        }
+        out.push(row);
+    }
+
+    out
+}
+
+fn column_to_row(A) {
+    let values = [];
+
+    for row in A {
+        values.push(row[0]);
+    }
+
+    row(values)
+}
+
+fn sum_squares(A) {
+    let total = 0.0;
+
+    for row in A {
+        for value in row {
+            total += value * value;
+        }
+    }
+
+    total
+}
+
+fn forward(W1, W2, x) {
+    let x_with_bias = vcat(x, col([1.0]));
+    let hidden = sigmoid_matrix(dot(W1, x_with_bias));
+    let hidden_with_bias = vcat(hidden, col([1.0]));
+    let output = sigmoid_matrix(dot(W2, hidden_with_bias));
+
+    #{
+        "x_with_bias": x_with_bias,
+        "hidden": hidden,
+        "hidden_with_bias": hidden_with_bias,
+        "output": output
+    }
+}
+
+fn total_loss(W1, W2, inputs, targets) {
+    let loss = 0.0;
+
+    for i in 0..inputs.len() {
+        let x = inputs[i];
+        let target_value = targets[i];
+        let step = forward(W1, W2, x);
+        let prediction = step.output;
+        let target = col([target_value]);
+        let residual = sub_matrix(prediction, target);
+        loss += 0.5 * sum_squares(residual);
+    }
+
+    loss
+}
+
+fn predictions(W1, W2, inputs) {
+    let out = [];
+
+    for x in inputs {
+        let prediction = forward(W1, W2, x).output;
+        let row = prediction[0];
+        out.push(row[0]);
+    }
+
+    out
+}
+
+let inputs = [
+    col([0.0, 0.0]),
+    col([0.0, 1.0]),
+    col([1.0, 0.0]),
+    col([1.0, 1.0])
+];
+let targets = [0.0, 1.0, 1.0, 0.0];
+
+// Fixed starting weights keep the example deterministic while still learning.
+let W1 = M("0.6888 0.5159 -0.1589; -0.4822 0.0225 -0.1901");
+let W2 = M("0.5676 -0.3934 -0.0468");
+let learning_rate = 1.5;
+let epochs = 800;
+let initial_loss = total_loss(W1, W2, inputs, targets);
+
+for epoch in 0..epochs {
+    for i in 0..inputs.len() {
+        let x = inputs[i];
+        let target_value = targets[i];
+        let step = forward(W1, W2, x);
+        let target = col([target_value]);
+
+        let output_error = sub_matrix(step.output, target);
+        let output_slope = sigmoid_prime_from_activation(step.output);
+        let output_delta = hadamard(output_error, output_slope);
+        let output_weight_row = W2[0];
+        let output_weights_without_bias = T(row([output_weight_row[0], output_weight_row[1]]));
+
+        let hidden_error = dot(output_weights_without_bias, output_delta);
+        let hidden_slope = sigmoid_prime_from_activation(step.hidden);
+        let hidden_delta = hadamard(hidden_error, hidden_slope);
+
+        let hidden_with_bias_row = column_to_row(step.hidden_with_bias);
+        let x_with_bias_row = column_to_row(step.x_with_bias);
+        let grad_W2 = dot(output_delta, hidden_with_bias_row);
+        let grad_W1 = dot(hidden_delta, x_with_bias_row);
+
+        W2 = sub_matrix(W2, scale_matrix(grad_W2, learning_rate));
+        W1 = sub_matrix(W1, scale_matrix(grad_W1, learning_rate));
+    }
+}
+
+let final_loss = total_loss(W1, W2, inputs, targets);
+let final_predictions = predictions(W1, W2, inputs);
+
+let result = #{
+    "initial_loss": initial_loss,
+    "final_loss": final_loss,
+    "predictions": final_predictions,
+    "W1": W1,
+    "W2": W2
+};
+
+print(result);
+result

--- a/examples/neural_network_backprop.rhai
+++ b/examples/neural_network_backprop.rhai
@@ -78,16 +78,6 @@ fn hadamard(A, B) {
     out
 }
 
-fn column_to_row(A) {
-    let values = [];
-
-    for row in A {
-        values.push(row[0]);
-    }
-
-    row(values)
-}
-
 fn sum_squares(A) {
     let total = 0.0;
 
@@ -174,10 +164,8 @@ for epoch in 0..epochs {
         let hidden_slope = sigmoid_prime_from_activation(step.hidden);
         let hidden_delta = hadamard(hidden_error, hidden_slope);
 
-        let hidden_with_bias_row = column_to_row(step.hidden_with_bias);
-        let x_with_bias_row = column_to_row(step.x_with_bias);
-        let grad_W2 = dot(output_delta, hidden_with_bias_row);
-        let grad_W1 = dot(hidden_delta, x_with_bias_row);
+        let grad_W2 = dot(output_delta, T(step.hidden_with_bias));
+        let grad_W1 = dot(hidden_delta, T(step.x_with_bias));
 
         W2 = sub_matrix(W2, scale_matrix(grad_W2, learning_rate));
         W1 = sub_matrix(W1, scale_matrix(grad_W1, learning_rate));

--- a/examples/neural_network_backprop.rs
+++ b/examples/neural_network_backprop.rs
@@ -1,0 +1,17 @@
+//! Trains a tiny neural network with backpropagation using rhai-sci matrices.
+
+fn main() {
+    #[cfg(feature = "nalgebra")]
+    {
+        use rhai::{packages::Package, Engine, Map};
+        use rhai_sci::SciPackage;
+
+        let mut engine = Engine::new();
+        engine.register_global_module(SciPackage::new().as_shared_module());
+
+        let result: Map = engine
+            .eval_file("examples/neural_network_backprop.rhai".into())
+            .expect("script should run");
+        println!("{result:?}");
+    }
+}

--- a/src/matrices_and_arrays.rs
+++ b/src/matrices_and_arrays.rs
@@ -257,6 +257,10 @@ pub mod matrix_functions {
     /// let c = T(row([1, 2, 3]));
     /// assert_eq(c, [[1.0], [2.0], [3.0]]);
     /// ```
+    /// ```typescript
+    /// let r = T(vec([1, 2, 3]));
+    /// assert_eq(r, [[1.0, 2.0, 3.0]]);
+    /// ```
     #[cfg(feature = "nalgebra")]
     #[rhai_fn(name = "T", return_raw)]
     pub fn transpose_alias(matrix: Array) -> Result<Array, Box<EvalAltResult>> {
@@ -540,11 +544,12 @@ pub mod matrix_functions {
     /// ```
     #[rhai_fn(name = "transpose", return_raw)]
     pub fn transpose(matrix: RhaiMatrix) -> Result<RhaiMatrix, Box<EvalAltResult>> {
-        let oriented = matrix
-            .as_row()
-            .or_else(|| matrix.as_column())
-            .unwrap_or(matrix);
-        oriented.transpose()
+        let mut raw = matrix.clone().to_array();
+        if !raw.is_empty() && matrix_size_by_reference(&mut raw).len() == 1 {
+            return RhaiMatrix::row_vector(raw).transpose();
+        }
+
+        matrix.transpose()
     }
 
     /// Transpose an array by first converting it to a [`RhaiMatrix`].

--- a/src/matrices_and_arrays.rs
+++ b/src/matrices_and_arrays.rs
@@ -158,6 +158,10 @@ pub mod matrix_functions {
     }
 
     /// Create a column vector from a compact numeric literal string.
+    /// ```typescript
+    /// let v = vec("1; 2; 3");
+    /// assert_eq(v, [[1], [2], [3]]);
+    /// ```
     #[rhai_fn(name = "vec", return_raw)]
     pub fn vec_from_string(values: ImmutableString) -> Result<Array, Box<EvalAltResult>> {
         col_from_string(values)
@@ -178,6 +182,10 @@ pub mod matrix_functions {
     }
 
     /// Create a row vector from a compact numeric literal string.
+    /// ```typescript
+    /// let r = R("1 2 3");
+    /// assert_eq(r, [[1, 2, 3]]);
+    /// ```
     #[rhai_fn(name = "row", name = "R", return_raw)]
     pub fn row_from_string(values: ImmutableString) -> Result<Array, Box<EvalAltResult>> {
         row_from_array(parse_matrix_literal(values)?)
@@ -198,6 +206,10 @@ pub mod matrix_functions {
     }
 
     /// Create a column vector from a compact numeric literal string.
+    /// ```typescript
+    /// let c = C("1; 2; 3");
+    /// assert_eq(c, [[1], [2], [3]]);
+    /// ```
     #[rhai_fn(name = "col", name = "C", return_raw)]
     pub fn col_from_string(values: ImmutableString) -> Result<Array, Box<EvalAltResult>> {
         col_from_array(parse_matrix_literal(values)?)
@@ -219,6 +231,10 @@ pub mod matrix_functions {
     }
 
     /// Create a numeric matrix from a compact literal string.
+    /// ```typescript
+    /// let A = M("1, 2; 3, 4");
+    /// assert_eq(A, [[1, 2], [3, 4]]);
+    /// ```
     #[rhai_fn(name = "mat", name = "M", return_raw)]
     pub fn mat_from_string(matrix: ImmutableString) -> Result<Array, Box<EvalAltResult>> {
         parse_matrix_literal(matrix)

--- a/src/matrices_and_arrays.rs
+++ b/src/matrices_and_arrays.rs
@@ -1,8 +1,135 @@
 use rhai::plugin::*;
 
+mod matrix_conventions {
+    use rhai::{Array, Dynamic, EvalAltResult, ImmutableString, Position, FLOAT, INT};
+
+    pub(super) fn vector_data_from_array(
+        values: Array,
+        constructor: &str,
+    ) -> Result<Array, Box<EvalAltResult>> {
+        if values.iter().all(is_numeric_scalar) {
+            return Ok(values);
+        }
+
+        let mut rows = Vec::with_capacity(values.len());
+        for row in values {
+            rows.push(row.into_array().map_err(|_| {
+                matrix_error(format!(
+                    "{constructor} expects a numeric list, row vector, or column vector"
+                ))
+            })?);
+        }
+
+        if rows.len() == 1 {
+            ensure_numeric_list(&rows[0], constructor)?;
+            return Ok(rows.remove(0));
+        }
+
+        if rows.iter().all(|row| {
+            row.len() == 1 && matches!(row.first(), Some(value) if is_numeric_scalar(value))
+        }) {
+            return Ok(rows.into_iter().map(|mut row| row.remove(0)).collect());
+        }
+
+        Err(matrix_error(format!(
+            "{constructor} expects a numeric list, row vector, or column vector"
+        )))
+    }
+
+    pub(super) fn parse_matrix_literal(
+        source: ImmutableString,
+    ) -> Result<Array, Box<EvalAltResult>> {
+        let mut matrix = Array::new();
+        let source = source.as_str();
+        if source.trim().is_empty() {
+            return Err(matrix_error("Matrix literal must not be empty"));
+        }
+
+        for row_text in source.split(';') {
+            let row_text = row_text.trim();
+            if row_text.is_empty() {
+                return Err(matrix_error("Matrix literal rows must not be empty"));
+            }
+
+            let normalized = row_text.replace(',', " ");
+            let mut row = Array::new();
+            for token in normalized.split_whitespace() {
+                row.push(parse_numeric_token(token)?);
+            }
+
+            if row.is_empty() {
+                return Err(matrix_error("Matrix literal rows must not be empty"));
+            }
+            matrix.push(Dynamic::from_array(row));
+        }
+
+        ensure_numeric_matrix(&matrix)?;
+        Ok(matrix)
+    }
+
+    fn parse_numeric_token(token: &str) -> Result<Dynamic, Box<EvalAltResult>> {
+        if !token.contains('.') && !token.contains('e') && !token.contains('E') {
+            if let Ok(value) = token.parse::<INT>() {
+                return Ok(Dynamic::from_int(value));
+            }
+        }
+
+        token
+            .parse::<FLOAT>()
+            .map(Dynamic::from_float)
+            .map_err(|_| matrix_error(format!("Invalid numeric literal `{token}`")))
+    }
+
+    pub(super) fn ensure_numeric_matrix(matrix: &Array) -> Result<(), Box<EvalAltResult>> {
+        if matrix.is_empty() {
+            return Err(matrix_error("mat expects at least one row"));
+        }
+
+        let mut cols = None;
+        for row in matrix {
+            let row = row
+                .clone()
+                .into_array()
+                .map_err(|_| matrix_error("mat expects nested row arrays"))?;
+
+            match cols {
+                Some(expected) if row.len() != expected => {
+                    return Err(matrix_error("Matrix rows must have equal length"));
+                }
+                None => cols = Some(row.len()),
+                _ => {}
+            }
+
+            ensure_numeric_list(&row, "mat")?;
+        }
+
+        Ok(())
+    }
+
+    fn ensure_numeric_list(values: &Array, constructor: &str) -> Result<(), Box<EvalAltResult>> {
+        if values.iter().all(is_numeric_scalar) {
+            Ok(())
+        } else {
+            Err(matrix_error(format!(
+                "{constructor} expects INT or FLOAT values"
+            )))
+        }
+    }
+
+    fn is_numeric_scalar(value: &Dynamic) -> bool {
+        value.is_int() || value.is_float()
+    }
+
+    fn matrix_error(message: impl Into<String>) -> Box<EvalAltResult> {
+        EvalAltResult::ErrorArithmetic(message.into(), Position::NONE).into()
+    }
+}
+
 #[export_module]
 pub mod matrix_functions {
-    #[cfg(feature = "nalgebra")]
+    use super::matrix_conventions::{
+        ensure_numeric_matrix, parse_matrix_literal, vector_data_from_array,
+    };
     use crate::matrix::{RhaiMatrix, RhaiVector};
     use crate::validation_functions::{is_column_vector, is_row_vector};
     use crate::{
@@ -13,8 +140,141 @@ pub mod matrix_functions {
     use crate::{if_matrices_and_compatible_convert_to_vec_array_and_do, FOIL};
     #[cfg(feature = "nalgebra")]
     use nalgebralib::DMatrix;
-    use rhai::{Array, Dynamic, EvalAltResult, Map, Position, FLOAT, INT};
+    use rhai::{Array, Dynamic, EvalAltResult, ImmutableString, Map, Position, FLOAT, INT};
     use std::collections::BTreeMap;
+
+    /// Create a column vector from a numeric list. This is the default vector convention.
+    /// ```typescript
+    /// let v = vec([1, 2, 3]);
+    /// assert_eq(v, [[1], [2], [3]]);
+    /// ```
+    /// ```typescript
+    /// let v = vec("1 2 3");
+    /// assert_eq(v, [[1], [2], [3]]);
+    /// ```
+    #[rhai_fn(name = "vec", return_raw)]
+    pub fn vec_from_array(values: Array) -> Result<Array, Box<EvalAltResult>> {
+        col_from_array(values)
+    }
+
+    /// Create a column vector from a compact numeric literal string.
+    #[rhai_fn(name = "vec", return_raw)]
+    pub fn vec_from_string(values: ImmutableString) -> Result<Array, Box<EvalAltResult>> {
+        col_from_string(values)
+    }
+
+    /// Create a row vector from a numeric list.
+    /// ```typescript
+    /// let r = row([1, 2, 3]);
+    /// assert_eq(r, [[1, 2, 3]]);
+    /// ```
+    /// ```typescript
+    /// let r = row("1 2 3");
+    /// assert_eq(r, [[1, 2, 3]]);
+    /// ```
+    #[rhai_fn(name = "row", return_raw)]
+    pub fn row_from_array(values: Array) -> Result<Array, Box<EvalAltResult>> {
+        Ok(RhaiMatrix::row_vector(vector_data_from_array(values, "row")?).to_array())
+    }
+
+    /// Create a row vector from a compact numeric literal string.
+    #[rhai_fn(name = "row", name = "R", return_raw)]
+    pub fn row_from_string(values: ImmutableString) -> Result<Array, Box<EvalAltResult>> {
+        row_from_array(parse_matrix_literal(values)?)
+    }
+
+    /// Create a column vector from a numeric list.
+    /// ```typescript
+    /// let c = col([1, 2, 3]);
+    /// assert_eq(c, [[1], [2], [3]]);
+    /// ```
+    /// ```typescript
+    /// let c = col("1; 2; 3");
+    /// assert_eq(c, [[1], [2], [3]]);
+    /// ```
+    #[rhai_fn(name = "col", return_raw)]
+    pub fn col_from_array(values: Array) -> Result<Array, Box<EvalAltResult>> {
+        Ok(RhaiMatrix::column_vector(vector_data_from_array(values, "col")?).to_array())
+    }
+
+    /// Create a column vector from a compact numeric literal string.
+    #[rhai_fn(name = "col", name = "C", return_raw)]
+    pub fn col_from_string(values: ImmutableString) -> Result<Array, Box<EvalAltResult>> {
+        col_from_array(parse_matrix_literal(values)?)
+    }
+
+    /// Validate and return a numeric matrix represented as nested row arrays.
+    /// ```typescript
+    /// let A = mat([[1, 2], [3, 4]]);
+    /// assert_eq(A, [[1, 2], [3, 4]]);
+    /// ```
+    /// ```typescript
+    /// let A = mat("1 2; 3 4");
+    /// assert_eq(A, [[1, 2], [3, 4]]);
+    /// ```
+    #[rhai_fn(name = "mat", return_raw)]
+    pub fn mat_from_array(matrix: Array) -> Result<Array, Box<EvalAltResult>> {
+        ensure_numeric_matrix(&matrix)?;
+        Ok(matrix)
+    }
+
+    /// Create a numeric matrix from a compact literal string.
+    #[rhai_fn(name = "mat", name = "M", return_raw)]
+    pub fn mat_from_string(matrix: ImmutableString) -> Result<Array, Box<EvalAltResult>> {
+        parse_matrix_literal(matrix)
+    }
+
+    /// Short alias for [`transpose`].
+    /// ```typescript
+    /// let c = T(row([1, 2, 3]));
+    /// assert_eq(c, [[1.0], [2.0], [3.0]]);
+    /// ```
+    #[cfg(feature = "nalgebra")]
+    #[rhai_fn(name = "T", return_raw)]
+    pub fn transpose_alias(matrix: Array) -> Result<Array, Box<EvalAltResult>> {
+        transpose_from_array(matrix)
+    }
+
+    /// Short alias for [`mtimes`].
+    /// ```typescript
+    /// let A = mat("1 2; 3 4");
+    /// let x = col([5, 6]);
+    /// assert_eq(dot(A, x), [[17.0], [39.0]]);
+    /// ```
+    /// ```typescript
+    /// let A = mat("1 2; 3 4");
+    /// let x = col([5, 6]);
+    /// assert_eq(A.dot(x), [[17.0], [39.0]]);
+    /// ```
+    #[cfg(feature = "nalgebra")]
+    #[rhai_fn(name = "dot", return_raw)]
+    pub fn dot(matrix1: Array, matrix2: Array) -> Result<Array, Box<EvalAltResult>> {
+        mtimes(matrix1, matrix2)
+    }
+
+    /// Short alias for [`horzcat`].
+    /// ```typescript
+    /// let A = mat("1 2; 3 4");
+    /// let x = col([5, 6]);
+    /// assert_eq(hcat(A, x), [[1.0, 2.0, 5.0], [3.0, 4.0, 6.0]]);
+    /// ```
+    #[cfg(feature = "nalgebra")]
+    #[rhai_fn(name = "hcat", return_raw)]
+    pub fn hcat(matrix1: Array, matrix2: Array) -> Result<Array, Box<EvalAltResult>> {
+        horzcat_from_array(matrix1, matrix2)
+    }
+
+    /// Short alias for [`vertcat`].
+    /// ```typescript
+    /// let A = mat("1 2; 3 4");
+    /// let y = row([5, 6]);
+    /// assert_eq(vcat(A, y), [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]);
+    /// ```
+    #[cfg(feature = "nalgebra")]
+    #[rhai_fn(name = "vcat", return_raw)]
+    pub fn vcat(matrix1: Array, matrix2: Array) -> Result<Array, Box<EvalAltResult>> {
+        vertcat_from_array(matrix1, matrix2)
+    }
 
     /// Calculates the inverse of a matrix. Fails if the matrix if not invertible, or if the
     /// elements of the matrix aren't FLOAT or INT.

--- a/src/matrices_and_arrays.rs
+++ b/src/matrices_and_arrays.rs
@@ -7,6 +7,10 @@ mod matrix_conventions {
         values: Array,
         constructor: &str,
     ) -> Result<Array, Box<EvalAltResult>> {
+        if values.is_empty() {
+            return Err(empty_values_error(constructor));
+        }
+
         if values.iter().all(is_numeric_scalar) {
             return Ok(values);
         }
@@ -107,6 +111,10 @@ mod matrix_conventions {
     }
 
     fn ensure_numeric_list(values: &Array, constructor: &str) -> Result<(), Box<EvalAltResult>> {
+        if values.is_empty() {
+            return Err(empty_values_error(constructor));
+        }
+
         if values.iter().all(is_numeric_scalar) {
             Ok(())
         } else {
@@ -118,6 +126,10 @@ mod matrix_conventions {
 
     fn is_numeric_scalar(value: &Dynamic) -> bool {
         value.is_int() || value.is_float()
+    }
+
+    fn empty_values_error(constructor: &str) -> Box<EvalAltResult> {
+        matrix_error(format!("{constructor} expects at least one value"))
     }
 
     fn matrix_error(message: impl Into<String>) -> Box<EvalAltResult> {

--- a/tests/matrix_conventions.rs
+++ b/tests/matrix_conventions.rs
@@ -73,6 +73,14 @@ fn matrix_constructor_rejects_ragged_literals() {
 fn matrix_constructor_rejects_invalid_arrays() {
     assert_error_contains("mat([[1, 2], [3]])", "equal length");
     assert_error_contains("mat([[1, \"x\"]])", "INT or FLOAT");
+    assert_error_contains("mat([[]])", "at least one value");
+}
+
+#[test]
+fn vector_constructors_reject_empty_arrays() {
+    assert_error_contains("vec([])", "at least one value");
+    assert_error_contains("row([])", "at least one value");
+    assert_error_contains("col([])", "at least one value");
 }
 
 fn eval_array(script: &str) -> Result<Array, Box<EvalAltResult>> {

--- a/tests/matrix_conventions.rs
+++ b/tests/matrix_conventions.rs
@@ -66,19 +66,32 @@ fn aliases_read_like_linear_algebra() {
 
 #[test]
 fn matrix_constructor_rejects_ragged_literals() {
-    let err = eval_array("mat(\"1 2; 3\")").unwrap_err();
-    match err.as_ref() {
-        EvalAltResult::ErrorArithmetic(message, _) => {
-            assert!(message.contains("equal length"));
-        }
-        other => panic!("unexpected error: {other:?}"),
-    }
+    assert_error_contains("mat(\"1 2; 3\")", "equal length");
+}
+
+#[test]
+fn matrix_constructor_rejects_invalid_arrays() {
+    assert_error_contains("mat([[1, 2], [3]])", "equal length");
+    assert_error_contains("mat([[1, \"x\"]])", "INT or FLOAT");
 }
 
 fn eval_array(script: &str) -> Result<Array, Box<EvalAltResult>> {
     let mut engine = Engine::new();
     engine.register_global_module(SciPackage::new().as_shared_module());
     engine.eval::<Array>(script)
+}
+
+fn assert_error_contains(script: &str, expected: &str) {
+    let err = eval_array(script).unwrap_err();
+    match err.as_ref() {
+        EvalAltResult::ErrorArithmetic(message, _) => {
+            assert!(
+                message.contains(expected),
+                "expected error message `{message}` to contain `{expected}`"
+            );
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
 }
 
 fn assert_matrix_eq(actual: Array, expected: &[&[f64]]) {

--- a/tests/matrix_conventions.rs
+++ b/tests/matrix_conventions.rs
@@ -1,0 +1,110 @@
+use rhai::{packages::Package, Array, Engine, EvalAltResult};
+use rhai_sci::SciPackage;
+
+#[test]
+fn constructors_make_vector_orientation_explicit() {
+    assert_matrix_eq(eval_array("row([1, 2, 3])").unwrap(), &[&[1.0, 2.0, 3.0]]);
+    assert_matrix_eq(
+        eval_array("col([1, 2, 3])").unwrap(),
+        &[&[1.0], &[2.0], &[3.0]],
+    );
+    assert_matrix_eq(
+        eval_array("vec([1, 2, 3])").unwrap(),
+        &[&[1.0], &[2.0], &[3.0]],
+    );
+}
+
+#[test]
+fn string_literals_accept_spaces_commas_and_semicolons() {
+    assert_matrix_eq(
+        eval_array("mat(\"1, 2; 3, 4\")").unwrap(),
+        &[&[1.0, 2.0], &[3.0, 4.0]],
+    );
+    assert_matrix_eq(
+        eval_array("M(\"1 2; 3 4\")").unwrap(),
+        &[&[1.0, 2.0], &[3.0, 4.0]],
+    );
+    assert_matrix_eq(eval_array("R(\"1 2 3\")").unwrap(), &[&[1.0, 2.0, 3.0]]);
+    assert_matrix_eq(
+        eval_array("C(\"1; 2; 3\")").unwrap(),
+        &[&[1.0], &[2.0], &[3.0]],
+    );
+}
+
+#[test]
+fn aliases_read_like_linear_algebra() {
+    let product = eval_array(
+        r#"
+            let A = mat("1 2; 3 4");
+            let x = col([5, 6]);
+            dot(A, x)
+        "#,
+    )
+    .unwrap();
+    assert_matrix_eq(product, &[&[17.0], &[39.0]]);
+
+    let method_product = eval_array(
+        r#"
+            let A = mat("1 2; 3 4");
+            let x = col([5, 6]);
+            A.dot(x)
+        "#,
+    )
+    .unwrap();
+    assert_matrix_eq(method_product, &[&[17.0], &[39.0]]);
+
+    assert_matrix_eq(eval_array("T(row([1, 2]))").unwrap(), &[&[1.0], &[2.0]]);
+    assert_matrix_eq(
+        eval_array("hcat(mat(\"1 2; 3 4\"), col([5, 6]))").unwrap(),
+        &[&[1.0, 2.0, 5.0], &[3.0, 4.0, 6.0]],
+    );
+    assert_matrix_eq(
+        eval_array("vcat(mat(\"1 2; 3 4\"), row([5, 6]))").unwrap(),
+        &[&[1.0, 2.0], &[3.0, 4.0], &[5.0, 6.0]],
+    );
+}
+
+#[test]
+fn matrix_constructor_rejects_ragged_literals() {
+    let err = eval_array("mat(\"1 2; 3\")").unwrap_err();
+    match err.as_ref() {
+        EvalAltResult::ErrorArithmetic(message, _) => {
+            assert!(message.contains("equal length"));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+fn eval_array(script: &str) -> Result<Array, Box<EvalAltResult>> {
+    let mut engine = Engine::new();
+    engine.register_global_module(SciPackage::new().as_shared_module());
+    engine.eval::<Array>(script)
+}
+
+fn assert_matrix_eq(actual: Array, expected: &[&[f64]]) {
+    let actual = numeric_matrix(actual);
+    let expected = expected
+        .iter()
+        .map(|row| row.to_vec())
+        .collect::<Vec<Vec<f64>>>();
+    assert_eq!(actual, expected);
+}
+
+fn numeric_matrix(matrix: Array) -> Vec<Vec<f64>> {
+    matrix
+        .into_iter()
+        .map(|row| {
+            row.into_array()
+                .expect("matrix rows should be arrays")
+                .into_iter()
+                .map(|value| {
+                    if value.is_float() {
+                        value.as_float().expect("value should be FLOAT")
+                    } else {
+                        value.as_int().expect("value should be INT") as f64
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}

--- a/tests/matrix_conventions.rs
+++ b/tests/matrix_conventions.rs
@@ -54,6 +54,11 @@ fn aliases_read_like_linear_algebra() {
     assert_matrix_eq(method_product, &[&[17.0], &[39.0]]);
 
     assert_matrix_eq(eval_array("T(row([1, 2]))").unwrap(), &[&[1.0], &[2.0]]);
+    assert_matrix_eq(eval_array("T(vec([1, 2]))").unwrap(), &[&[1.0, 2.0]]);
+    assert_matrix_eq(
+        eval_array("dot(T(vec([1, 2])), vec([3, 4]))").unwrap(),
+        &[&[11.0]],
+    );
     assert_matrix_eq(
         eval_array("hcat(mat(\"1 2; 3 4\"), col([5, 6]))").unwrap(),
         &[&[1.0, 2.0, 5.0], &[3.0, 4.0, 6.0]],

--- a/tests/matrix_ops.rs
+++ b/tests/matrix_ops.rs
@@ -18,6 +18,22 @@ fn transpose_orients_row_vector() {
 }
 
 #[test]
+fn transpose_orients_column_vector() {
+    let data: Array = vec![
+        Dynamic::from_int(1),
+        Dynamic::from_int(2),
+        Dynamic::from_int(3),
+    ];
+    let column = RhaiMatrix::column_vector(data);
+    let mut result = transpose(column).unwrap().to_array();
+    assert!(is_row_vector(&mut result));
+
+    let row = result[0].clone().into_array().unwrap();
+    let values: Vec<FLOAT> = row.into_iter().map(|d| d.as_float().unwrap()).collect();
+    assert_eq!(values, vec![1.0, 2.0, 3.0]);
+}
+
+#[test]
 fn horzcat_concatenates_rows() {
     let a: Array = vec![Dynamic::from_int(1), Dynamic::from_int(2)];
     let b: Array = vec![Dynamic::from_int(3), Dynamic::from_int(4)];

--- a/tests/neural_network_backprop_example.rs
+++ b/tests/neural_network_backprop_example.rs
@@ -1,0 +1,30 @@
+#![cfg(feature = "nalgebra")]
+
+use rhai::{packages::Package, Array, Engine, Map};
+use rhai_sci::SciPackage;
+
+#[test]
+fn neural_network_backprop_example_learns_xor() {
+    let mut engine = Engine::new();
+    engine.register_global_module(SciPackage::new().as_shared_module());
+
+    let result: Map = engine
+        .eval_file("examples/neural_network_backprop.rhai".into())
+        .expect("script evaluation should succeed");
+
+    let initial_loss = result["initial_loss"].clone().cast::<f64>();
+    let final_loss = result["final_loss"].clone().cast::<f64>();
+    let predictions = result["predictions"].clone().cast::<Array>();
+    let predictions = predictions
+        .into_iter()
+        .map(|value| value.cast::<f64>())
+        .collect::<Vec<_>>();
+
+    assert!(initial_loss > 0.45);
+    assert!(final_loss < 0.02);
+    assert!(final_loss < initial_loss);
+    assert!(predictions[0] < 0.15);
+    assert!(predictions[1] > 0.85);
+    assert!(predictions[2] > 0.85);
+    assert!(predictions[3] < 0.15);
+}


### PR DESCRIPTION
## Summary
- Add explicit Rhai constructors for matrix/vector intent: `vec`, `row`, `col`, `mat`, plus `M`, `R`, and `C` string-literal shorthands.
- Add readability aliases for existing matrix operations: `dot`, `T`, `hcat`, and `vcat`.
- Document matrix/vector conventions in the README and add integration coverage for constructors, aliases, string literals, method-style `dot`, and ragged literal errors.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --no-default-features --features rand,nalgebra`
- `cargo test --no-default-features --features nalgebra,rand,metadata`